### PR TITLE
docs: add documentation links to README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,3 +3,9 @@
 **Entrypoint:** `schema.json`
 
 **Licensing:** The schema is licensed under CC0 (see `LICENSE-SCHEMA.txt`). Any code in this repository is licensed under MIT (see `LICENSE-CODE.txt`).
+
+## Documentation
+
+- **HTML Documentation:** [https://quadriga-dk.github.io/quadriga-schema/](https://quadriga-dk.github.io/quadriga-schema/)
+- **Latest Schema:** [https://quadriga-dk.github.io/quadriga-schema/latest/](https://quadriga-dk.github.io/quadriga-schema/latest/)
+- **Versioned Documentation:** Available for each version in the repository


### PR DESCRIPTION
Added a Documentation section to README md with links to the GitHub Pages HTML documentation, latest schema version, and versioned documentation structure.