### PR TITLE
feat: Remove unnecessary object indirection in prerequisites

### DIFF
--- a/v1.0.0/prerequisites.json
+++ b/v1.0.0/prerequisites.json
@@ -6,15 +6,7 @@
   "minItems": 1,
   "uniqueItems": true,
   "items": {
-    "type": "object",
-    "description": "Eine Voraussetzung.",
-    "additionalProperties": false,
-    "properties": {
-      "description": {
-        "$ref": "multilingual-text.json"
-      }
-    },
-    "required": ["description"]
+    "$ref": "multilingual-text.json"
   },
   "x-mappings": {
     "dc": null,


### PR DESCRIPTION
Simplify the prerequisites schema so each array item is a multilingual 
text string instead of an object with a single "description" key.