### PR TITLE
fix: Disable link_to_reused_ref to fix contributor HTML rendering

### DIFF
--- a/build-html.sh
+++ b/build-html.sh
@@ -38,7 +38,7 @@ for version_dir in v*/; do
   if [ -d "$version_dir" ] && [ -f "$version_dir/schema.json" ]; then
     echo "Building HTML for $version_dir"
     mkdir -p "_build/$version_dir"
-    generate-schema-doc --config custom_template_path=templates/js/base.html "$version_dir/schema.json" "_build/$version_dir/schema.html"
+    generate-schema-doc --config custom_template_path=templates/js/base.html --config link_to_reused_ref=false "$version_dir/schema.json" "_build/$version_dir/schema.html"
     # Create index.html redirect in version folder
     echo '<meta http-equiv="Refresh" content="0; url=schema.html" />' > "_build/$version_dir/index.html"
   fi
@@ -48,7 +48,7 @@ done
 if [ -f "latest/schema.json" ]; then
   echo "Building HTML for latest"
   mkdir -p "_build/latest"
-  generate-schema-doc --config custom_template_path=templates/js/base.html "latest/schema.json" "_build/latest/schema.html"
+  generate-schema-doc --config custom_template_path=templates/js/base.html --config link_to_reused_ref=false "latest/schema.json" "_build/latest/schema.html"
   # Create index.html redirect in latest folder
   echo '<meta http-equiv="Refresh" content="0; url=schema.html" />' > "_build/latest/index.html"
 fi


### PR DESCRIPTION
The HTML documentation was not correctly showing both ways to define a contributor (string vs object). This was due to json-schema-for-humans defaulting to link_to_reused_ref=true, which replaces subsequent $ref usages with anchor links to the first occurrence instead of rendering them fully.

Setting link_to_reused_ref=false in the build configuration ensures that the person.json and other references are expanded properly for all referencing fields.

Fixes #67