### PR TITLE
fix: Update vocabulary mappings template to support multiple mappings per vocabulary

### DIFF
--- a/templates/js/section_x_mappings.html
+++ b/templates/js/section_x_mappings.html
@@ -25,7 +25,53 @@
             </thead>
             <tbody>
             {%- for vocab, mapping_node in x_mappings_node.keywords.items() -%}
-                {%- if mapping_node and mapping_node.keywords -%}
+                {%- if mapping_node and mapping_node.items -%}
+                    {# Handle array of mappings #}
+                    {%- for mapping_item in mapping_node.items -%}
+                        {%- set property_node = mapping_item.keywords.get('property') -%}
+                        {%- set relation_node = mapping_item.keywords.get('relation') -%}
+                        <tr>
+                            <td>
+                            {%- if vocab in context_mapping -%}
+                                <a href="{{ context_mapping[vocab] }}" target="_blank" rel="noopener noreferrer"><code>{{ vocab }}</code></a>
+                            {%- else -%}
+                                <code>{{ vocab }}</code>
+                            {%- endif -%}
+                            </td>
+                            <td>
+                            {%- if relation_node -%}
+                                {%- set relation_parts = relation_node.literal.split(':') -%}
+                                {%- if relation_parts|length == 2 and relation_parts[0] in context_mapping -%}
+                                    {%- set relation_url = context_mapping[relation_parts[0]] ~ relation_parts[1] -%}
+                                    <a href="{{ relation_url }}" target="_blank" rel="noopener noreferrer">
+                                        <span class="badge badge-secondary">{{ relation_node.literal }}</span>
+                                    </a>
+                                {%- else -%}
+                                    <span class="badge badge-secondary">{{ relation_node.literal }}</span>
+                                {%- endif -%}
+                            {%- else -%}
+                                <span class="text-muted">N/A</span>
+                            {%- endif -%}
+                            </td>
+                            <td>
+                            {%- if property_node -%}
+                                {%- set property_parts = property_node.literal.split(':') -%}
+                                {%- if property_parts|length == 2 and property_parts[0] in context_mapping -%}
+                                    {%- set property_url = context_mapping[property_parts[0]] ~ property_parts[1] -%}
+                                    <a href="{{ property_url }}" target="_blank" rel="noopener noreferrer">
+                                        <code>{{ property_node.literal }}</code>
+                                    </a>
+                                {%- else -%}
+                                    <code>{{ property_node.literal }}</code>
+                                {%- endif -%}
+                            {%- else -%}
+                                <span class="text-muted">N/A</span>
+                            {%- endif -%}
+                            </td>
+                        </tr>
+                    {%- endfor -%}
+                {%- elif mapping_node and mapping_node.keywords -%}
+                    {# Handle single mapping object #}
                     {%- set property_node = mapping_node.keywords.get('property') -%}
                     {%- set relation_node = mapping_node.keywords.get('relation') -%}
                     <tr>
@@ -68,6 +114,7 @@
                         </td>
                     </tr>
                 {%- else -%}
+                    {# Handle null mapping #}
                     <tr>
                         <td>
                         {%- if vocab in context_mapping -%}


### PR DESCRIPTION
The x-mappings-meta-schema was updated to allow array of mappings for each
vocabulary, but the template section_x_mappings.html only handled single
mapping objects. This update adds support for displaying multiple mappings
by checking if a vocabulary has an array of mappings and iterating over
each one to create separate table rows.

The template now correctly handles:
- Arrays of mappings (multiple rows with same vocabulary name)
- Single mapping objects (one row)
- Null mappings (N/A values)