### PR TITLE
fix: Correct array detection in vocabulary mappings template

### DIFF
--- a/templates/js/section_x_mappings.html
+++ b/templates/js/section_x_mappings.html
@@ -25,9 +25,9 @@
             </thead>
             <tbody>
             {%- for vocab, mapping_node in x_mappings_node.keywords.items() -%}
-                {%- if mapping_node and mapping_node.items -%}
+                {%- if mapping_node and mapping_node.array_items -%}
                     {# Handle array of mappings #}
-                    {%- for mapping_item in mapping_node.items -%}
+                    {%- for mapping_item in mapping_node.array_items -%}
                         {%- set property_node = mapping_item.keywords.get('property') -%}
                         {%- set relation_node = mapping_item.keywords.get('relation') -%}
                         <tr>


### PR DESCRIPTION
The merged PR #69 used mapping_node.items to detect arrays, but the json-schema-for-humans template system uses .array_items attribute for array nodes, not .items. This fixes the display of vocabularies with multiple mappings (e.g., keywords.json with multiple schema mappings).