### PR TITLE
feat: Combine multiple vocabulary mappings into single row with rowspan

### DIFF
--- a/templates/js/section_x_mappings.html
+++ b/templates/js/section_x_mappings.html
@@ -31,13 +31,15 @@
                         {%- set property_node = mapping_item.keywords.get('property') -%}
                         {%- set relation_node = mapping_item.keywords.get('relation') -%}
                         <tr>
-                            <td>
+                            {%- if loop.first -%}
+                            <td rowspan="{{ mapping_node.array_items|length }}">
                             {%- if vocab in context_mapping -%}
                                 <a href="{{ context_mapping[vocab] }}" target="_blank" rel="noopener noreferrer"><code>{{ vocab }}</code></a>
                             {%- else -%}
                                 <code>{{ vocab }}</code>
                             {%- endif -%}
                             </td>
+                            {%- endif -%}
                             <td>
                             {%- if relation_node -%}
                                 {%- set relation_parts = relation_node.literal.split(':') -%}


### PR DESCRIPTION
When a vocabulary has multiple mappings (e.g., schema.org with both
schema:keywords and schema:about), display them in a combined format
with the vocabulary name shown once using rowspan, and the relationship
and property columns showing each mapping on separate rows.

This improves readability by eliminating redundant vocabulary names
in the first column while clearly showing all mappings.