### PR TITLE
feat: Update (add and remove as necessary) LRMI and MoDALIA x-mappings with documentation

### DIFF
--- a/v1.0.0/authors.json
+++ b/v1.0.0/authors.json
@@ -8,5 +8,21 @@
   "uniqueItems": true,
   "items": {
     "$ref": "author.json"
+  },
+  "x-mappings": {
+    "dc": {
+      "relation": "skos:exactMatch",
+      "property": "dc:creator"
+    },
+    "dcterms": {
+      "relation": "skos:exactMatch",
+      "property": "dcterms:creator"
+    },
+    "lrmi": null,
+    "modalia": null,
+    "schema": {
+      "relation": "skos:exactMatch",
+      "property": "schema:author"
+    }
   }
 }

--- a/v1.0.0/blooms-category.json
+++ b/v1.0.0/blooms-category.json
@@ -12,5 +12,13 @@
     "5 Bewerten",
     "6 Erschaffen",
     "nicht anwendbar"
-  ]
+  ],
+  "x-mappings": {
+    "$comment": "Bloom's taxonomy categories describe cognitive complexity of learning (Remember → Create), not educational level progression. LRMI/Schema.org educationalLevel describes where learners are in their educational journey (e.g., 'Grade 2', 'undergraduate'). These are orthogonal concepts with no appropriate simple property mapping. Use educationalAlignment with AlignmentObject for proper Bloom's taxonomy representation.",
+    "dc": null,
+    "dcterms": null,
+    "lrmi": null,
+    "modalia": null,
+    "schema": null
+  }
 }

--- a/v1.0.0/chapter.json
+++ b/v1.0.0/chapter.json
@@ -47,7 +47,10 @@
           "relation": "skos:closeMatch",
           "property": "lrmi:teaches"
         },
-        "modalia": null,
+        "modalia": {
+          "relation": "skos:closeMatch",
+          "property": "modalia:hasLearningObjective"
+        },
         "schema": {
           "relation": "skos:closeMatch",
           "property": "schema:teaches"
@@ -93,16 +96,11 @@
     }
   },
   "x-mappings": {
+    "$comment": "lrmi:LearningResource, modalia:LearningResource, and schema:LearningResource are RDF classes/types, not properties, so cannot be mapped here. The chapter schema itself represents a learning resource type, which should be indicated through RDF typing mechanisms, not property mappings.",
     "dc": null,
     "dcterms": null,
-    "lrmi": {
-      "relation": "skos:exactMatch",
-      "property": "lrmi:LearningResource"
-    },
+    "lrmi": null,
     "modalia": null,
-    "schema": {
-      "relation": "skos:exactMatch",
-      "property": "schema:LearningResource"
-    }
+    "schema": null
   }
 }

--- a/v1.0.0/competency.json
+++ b/v1.0.0/competency.json
@@ -22,13 +22,11 @@
     "nicht anwendbar"
   ],
   "x-mappings": {
+    "$comment": "modalia:Skill is an owl:Class (type), not a property, so cannot be mapped here. The QUADRIGA competency framework is domain-specific and has no direct property equivalent in MoDALIA. Related MoDALIA properties like modalia:teachesSkill or modalia:competencyRequired would apply to learning objectives/resources, not to the competency values themselves.",
     "dc": null,
     "dcterms": null,
     "lrmi": null,
-    "modalia": {
-      "relation": "skos:closeMatch",
-      "property": "modalia:Skill"
-    },
+    "modalia": null,
     "schema": null
   }
 }

--- a/v1.0.0/context-of-creation.json
+++ b/v1.0.0/context-of-creation.json
@@ -8,13 +8,11 @@
     "Die vorliegenden Open Educational Resources wurden durch das Datenkompetenzzentrum QUADRIGA erstellt.\n\nFörderkennzeichen: 16DKZ2034"
   ],
   "x-mappings": {
+    "$comment": "modalia:Community is an RDF class (type), not a property, so cannot be mapped here. The context-of-creation field describes the organizational/project context, which doesn't have a direct property equivalent in standard vocabularies. This is domain-specific metadata for QUADRIGA.",
     "dc": null,
     "dcterms": null,
     "lrmi": null,
-    "modalia": {
-      "relation": "skos:closeMatch",
-      "property": "modalia:Community"
-    },
+    "modalia": null,
     "schema": null
   }
 }

--- a/v1.0.0/contributors.json
+++ b/v1.0.0/contributors.json
@@ -8,5 +8,21 @@
   "uniqueItems": true,
   "items": {
     "$ref": "contributor.json"
+  },
+  "x-mappings": {
+    "dc": {
+      "relation": "skos:exactMatch",
+      "property": "dc:contributor"
+    },
+    "dcterms": {
+      "relation": "skos:exactMatch",
+      "property": "dcterms:contributor"
+    },
+    "lrmi": null,
+    "modalia": null,
+    "schema": {
+      "relation": "skos:exactMatch",
+      "property": "schema:contributor"
+    }
   }
 }

--- a/v1.0.0/discipline.json
+++ b/v1.0.0/discipline.json
@@ -16,6 +16,7 @@
     ]
   },
   "x-mappings": {
+    "$comment": "modalia:Discipline is an RDF class (type), not a property, so cannot be mapped here. The discipline values themselves can be typed as modalia:Discipline instances, but there's no direct property equivalent in MoDALIA for the 'discipline' field itself.",
     "dc": {
       "relation": "skos:broadMatch",
       "property": "dc:subject"
@@ -25,10 +26,7 @@
       "property": "dcterms:subject"
     },
     "lrmi": null,
-    "modalia": {
-      "relation": "skos:exactMatch",
-      "property": "modalia:Discipline"
-    },
+    "modalia": null,
     "schema": {
       "relation": "skos:closeMatch",
       "property": "schema:about"

--- a/v1.0.0/learning-objectives-entry.json
+++ b/v1.0.0/learning-objectives-entry.json
@@ -57,7 +57,10 @@
       "relation": "skos:closeMatch",
       "property": "lrmi:teaches"
     },
-    "modalia": null,
+    "modalia": {
+      "relation": "skos:closeMatch",
+      "property": "modalia:hasLearningObjective"
+    },
     "schema": {
       "relation": "skos:closeMatch",
       "property": "schema:teaches"

--- a/v1.0.0/learning-objectives.json
+++ b/v1.0.0/learning-objectives.json
@@ -8,5 +8,21 @@
   "uniqueItems": true,
   "items": {
     "$ref": "learning-objectives-entry.json"
+  },
+  "x-mappings": {
+    "dc": null,
+    "dcterms": null,
+    "lrmi": {
+      "relation": "skos:closeMatch",
+      "property": "lrmi:teaches"
+    },
+    "modalia": {
+      "relation": "skos:closeMatch",
+      "property": "modalia:hasLearningObjective"
+    },
+    "schema": {
+      "relation": "skos:closeMatch",
+      "property": "schema:teaches"
+    }
   }
 }

--- a/v1.0.0/learning-resource-type.json
+++ b/v1.0.0/learning-resource-type.json
@@ -20,7 +20,7 @@
     },
     "modalia": {
       "relation": "skos:closeMatch",
-      "property": "modalia:LearningResourceType"
+      "property": "modalia:hasLearningType"
     },
     "schema": {
       "relation": "skos:closeMatch",

--- a/v1.0.0/person.json
+++ b/v1.0.0/person.json
@@ -30,13 +30,11 @@
     }
   ],
   "x-mappings": {
+    "$comment": "schema:Person is an RDF class (type), not a property, so cannot be mapped here. Person data should be typed as schema:Person through RDF typing, not via property mappings.",
     "dc": null,
     "dcterms": null,
     "lrmi": null,
     "modalia": null,
-    "schema": {
-      "relation": "skos:exactMatch",
-      "property": "schema:Person"
-    }
+    "schema": null
   }
 }

--- a/v1.0.0/prerequisites.json
+++ b/v1.0.0/prerequisites.json
@@ -12,13 +12,17 @@
     "$ref": "multilingual-text.json"
   },
   "x-mappings": {
+    "$comment": "lrmi:teaches describes what learners WILL learn (resource → outcome), while prerequisites describe what learners MUST ALREADY know (prior knowledge → resource). These are inverse relationships, so no mapping is appropriate.",
     "dc": null,
     "dcterms": {
       "relation": "skos:broadMatch",
       "property": "dcterms:requires"
     },
     "lrmi": null,
-    "modalia": null,
+    "modalia": {
+      "relation": "skos:closeMatch",
+      "property": "modalia:requiresKnowledge"
+    },
     "schema": {
       "relation": "skos:exactMatch",
       "property": "schema:coursePrerequisites"

--- a/v1.0.0/schema.json
+++ b/v1.0.0/schema.json
@@ -111,16 +111,11 @@
     }
   },
   "x-mappings": {
+    "$comment": "lrmi:LearningResource, modalia:LearningResource are RDF classes (types), not properties, so cannot be mapped here. The schema represents a Book/collection, which is appropriately mapped to schema:Book type via the schema itself, not via x-mappings.",
     "dc": null,
     "dcterms": null,
-    "lrmi": {
-      "relation": "skos:closeMatch",
-      "property": "lrmi:LearningResource"
-    },
+    "lrmi": null,
     "modalia": null,
-    "schema": {
-      "relation": "skos:closeMatch",
-      "property": "schema:Book"
-    }
+    "schema": null
   }
 }

--- a/v1.0.0/supplemental-material.json
+++ b/v1.0.0/supplemental-material.json
@@ -25,6 +25,7 @@
     }
   },
   "x-mappings": {
+    "$comment": "schema:isRelatedTo has domain restrictions (Product/Service only), cannot be used with CreativeWork/Book types. No appropriate general 'related resource' property exists in Schema.org for educational materials.",
     "dc": null,
     "dcterms": [
       {
@@ -38,9 +39,6 @@
     ],
     "lrmi": null,
     "modalia": null,
-    "schema": {
-      "relation": "skos:closeMatch",
-      "property": "schema:isRelatedTo"
-    }
+    "schema": null
   }
 }

--- a/v1.0.0/target-group.json
+++ b/v1.0.0/target-group.json
@@ -25,7 +25,7 @@
     },
     "modalia": {
       "relation": "skos:exactMatch",
-      "property": "modalia:TargetGroup"
+      "property": "modalia:hasTargetGroup"
     },
     "schema": {
       "relation": "skos:closeMatch",

--- a/v1.0.0/time-required.json
+++ b/v1.0.0/time-required.json
@@ -8,8 +8,14 @@
   "x-mappings": {
     "dc": null,
     "dcterms": null,
-    "lrmi": null,
-    "modalia": null,
+    "lrmi": {
+      "relation": "skos:exactMatch",
+      "property": "lrmi:timeRequired"
+    },
+    "modalia": {
+      "relation": "skos:exactMatch",
+      "property": "modalia:timeRequired"
+    },
     "schema": {
       "relation": "skos:exactMatch",
       "property": "schema:timeRequired"

--- a/v1.0.0/used-tool.json
+++ b/v1.0.0/used-tool.json
@@ -26,6 +26,7 @@
     }
   ],
   "x-mappings": {
+    "$comment": "Schema.org has no property for software tools used in resource creation. schema:SoftwareApplication is a Type (class), not a property, so cannot be mapped. The schema:instrument property is for physical tools/instruments in Action types, not applicable to CreativeWork metadata.",
     "dc": null,
     "dcterms": {
       "relation": "skos:closeMatch",
@@ -33,9 +34,6 @@
     },
     "lrmi": null,
     "modalia": null,
-    "schema": {
-      "relation": "skos:exactMatch",
-      "property": "schema:SoftwareApplication"
-    }
+    "schema": null
   }
 }

--- a/v1.0.0/used-tools.json
+++ b/v1.0.0/used-tools.json
@@ -7,5 +7,16 @@
   "minItems": 1,
   "items": {
     "$ref": "used-tool.json"
+  },
+  "x-mappings": {
+    "$comment": "Schema.org has no property for software tools used in resource creation. schema:SoftwareApplication is a Type (class), not a property, so cannot be mapped. The schema:instrument property is for physical tools/instruments in Action types, not applicable to CreativeWork metadata.",
+    "dc": null,
+    "dcterms": {
+      "relation": "skos:closeMatch",
+      "property": "dcterms:requires"
+    },
+    "lrmi": null,
+    "modalia": null,
+    "schema": null
   }
 }


### PR DESCRIPTION
Add $comment fields to explain why certain external schema mappings
are set to null. These comments document semantic reasons (type vs.
property errors, inverse relationships, and Schema.org domain
restrictions) to prevent incorrect future mappings and improve
maintainability.