### PR TITLE
fix: Update mappings for research-object-type

### DIFF
--- a/v1.0.0/research-object-type.json
+++ b/v1.0.0/research-object-type.json
@@ -7,32 +7,22 @@
   "minItems": 1,
   "maxItems": 2,
   "items": {
-    "enum": [
-      "Text",
-      "Tabelle",
-      "Bewegtes Bild",
-      "übergreifend"
-    ]
+    "enum": ["Text", "Tabelle", "Bewegtes Bild", "übergreifend"]
   },
   "x-mappings": {
-    "dc": null,
+    "dc": {
+      "relation": "skos:broadMatch",
+      "target": "dc:subject"
+    },
     "dcat": null,
-    "dcterms": null,
-    "hermes": [
-      {
-        "$comment": "HERMES Attribut #21: Medientyp",
-        "relation": "skos:closeMatch",
-        "target": "dcterms:type"
-      },
-      {
-        "$comment": "HERMES Attribut #21: Medientyp",
-        "relation": "skos:closeMatch",
-        "target": "schema:mediaObject"
-      }
-    ],
+    "dcterms": {
+      "relation": "skos:broadMatch",
+      "target": "dcterms:subject"
+    },
+    "hermes": null,
     "lrmi": null,
     "modalia": {
-      "relation": "skos:closeMatch",
+      "relation": "skos:narrowMatch",
       "target": "modalia:coversManagementOfDataKind"
     },
     "schema": {


### PR DESCRIPTION
Our `research-object-type` is a description of the content of the book /
chapters / OER but with a very specific list of possible values.

This metadata field / property does not describe the
nature/structure/datatype of the book, so mappings to type should not
be made here.

The mapping to MoDALIA shows that the content concerns itself with data
literacy (not just research data management) of a specific kind of data.

Fixes #116.