### PR TITLE
fix(build): ASCII-escape non-ASCII chars in published JSON files

### DIFF
--- a/ascii-escape-json.py
+++ b/ascii-escape-json.py
@@ -1,0 +1,22 @@
+#!/usr/bin/env python3
+"""Re-serialize a JSON file with ASCII-only encoding (non-ASCII → \\uXXXX).
+
+This ensures browsers display characters correctly when served without
+a charset=utf-8 Content-Type header (e.g., on GitHub Pages).
+
+Usage: ascii-escape-json.py <source> <destination>
+"""
+
+import json
+import sys
+
+if len(sys.argv) != 3:
+    print(f"Usage: {sys.argv[0]} <source> <destination>", file=sys.stderr)
+    sys.exit(1)
+
+with open(sys.argv[1]) as f:
+    data = json.load(f)
+
+with open(sys.argv[2], "w") as f:
+    json.dump(data, f, indent=2, ensure_ascii=True)
+    f.write("\n")


### PR DESCRIPTION
Browsers may not display UTF-8 JSON correctly when GitHub Pages
serves files without charset=utf-8 in the Content-Type header.

Add ascii-escape-json.py helper that re-serializes JSON with
ensure_ascii=True, converting characters like ü to \u00fc.
Update the justfile html recipe to use this when copying JSON
files to _build/, keeping source files human-readable.